### PR TITLE
[PR] update pipeline by creating two images instead of one

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,4 +64,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/oxygencsgrp1eq8:latest-${{ steps.time.outputs.time }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/oxygencsgrp1eq8:${{ steps.time.outputs.time }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/oxygencsgrp1eq8:latest


### PR DESCRIPTION
# Type of changes :
- [ ] New feature
- [x] Bug fix

# Type of tests:
- [x] Manual tests
- [ ] Unit tests

# Description of the changes:
When a push is made on the main branch of the oxygencs app, the pipeline creates two images. The first image have a unique tag, and the second have the tag "latest".